### PR TITLE
Swipe to switch slide is now optional

### DIFF
--- a/src/components/Deck.js
+++ b/src/components/Deck.js
@@ -12,12 +12,14 @@ export default class Deck extends Component {
     className: PropTypes.string,
     footer: PropTypes.node,
     navigation: PropTypes.bool,
+    swipeToChange: PropTypes.bool,
   };
 
   static defaultProps = {
     className: '',
     footer: undefined,
     navigation: false,
+    swipeToChange: true,
   };
 
   state = {
@@ -79,9 +81,18 @@ export default class Deck extends Component {
   };
 
   render() {
-    const { className, footer, navigation } = this.props;
+    const {
+      className,
+      footer,
+      navigation,
+      swipeToChange,
+    } = this.props;
     return (
-      <Swipe onSwipeLeft={this.getNextSlide} onSwipeRight={this.getPreviousSlide} allowMouseEvents>
+      <Swipe
+        onSwipeLeft={swipeToChange ? this.getNextSlide : undefined}
+        onSwipeRight={swipeToChange ? this.getPreviousSlide : undefined}
+        allowMouseEvents
+      >
         <div className={`diorama diorama-deck ${className}`}>
           {footer && footer}
           {navigation && (


### PR DESCRIPTION
Deck now takes an argument (true by default) to set the swipeToChange mode. If set to false, the user won't be able to swipe to switch slide. Useful if you have code samples that you want to select in the slides.